### PR TITLE
add basePath and auto reload setting

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import settings, {
 import { getBlockContent } from './utils';
 
 function main() {
-  const { apiKey, model, customPrompts, tag } =
+  const { apiKey, basePath, model, customPrompts, tag } =
     logseq.settings as unknown as ISettings;
   const prompts = [...Object.values(presetPrompts)];
 
@@ -20,6 +20,7 @@ function main() {
   prompts.map(({ name, prompt, output }: IPromptOptions) => {
     const configuration = new Configuration({
       apiKey,
+      basePath
     });
 
     const openai = new OpenAIApi(configuration);
@@ -74,6 +75,7 @@ function main() {
         }
       },
     );
+    logseq.onSettingsChanged(() => main())
   });
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,7 @@ export interface IPromptOptions {
 
 export interface ISettings {
   apiKey: string;
+  basePath: string;
   model: string;
   tag: string;
   customPrompts: {
@@ -29,6 +30,13 @@ const settings: SettingSchemaDesc[] = [
     title: 'API Key',
     description: 'Enter your OpenAI API key.',
     default: '',
+  },
+  {
+    key: 'basePath',
+    type: 'string',
+    title: 'openApi basePath',
+    description: 'Enter your openApi proxy basePath',
+    default: 'https://api.openai.com/v1',
   },
   {
     key: 'model',


### PR DESCRIPTION
1.  Add the `basePath` field in the settings to support custom domain names.
2. The changes to the configuration will take effect automatically once modified