### PR TITLE
feat: get and send all the children blocks with getBlockContent

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,17 @@
 import { BlockEntity } from '@logseq/libs/dist/LSPlugin.user';
 
-export async function getBlockContent(block: BlockEntity) {
-  let content = block.content ?? '';
+export async function getBlockContent(block: BlockEntity, parentBlock = true, level = 1, content = '') {
+  if (parentBlock) {
+    content = block.content ?? '';
+  }
   const childrens = [block.children];
 
-  let level = 1;
   while (childrens.length > 0) {
     const children = childrens.shift();
     for (const child of children!) {
       content += '\n' + '\t'.repeat(level) + '- ' + (child as BlockEntity).content;
+      content += await getBlockContent((child as BlockEntity), false, level + 1)
     }
-    level += 1;
   }
 
   return content;


### PR DESCRIPTION
Update getBlockContent to recursively retrieve all the children blocks.

resolves #13.