### PR TITLE
Add append mode for GPT response rendering

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -129,6 +129,9 @@ function main() {
           case PromptOutputType.replace:
             await logseq.Editor.updateBlock(uuid, `${response}${tag}`);
             break;
+          case PromptOutputType.append:
+            await logseq.Editor.updateBlock(uuid, `${block?.content} ${response}${tag}`);
+            break;
         }
       },
     );

--- a/src/prompts/type.ts
+++ b/src/prompts/type.ts
@@ -9,4 +9,5 @@ export enum PromptOutputType {
   property = 'property',
   replace = 'replace',
   insert = 'insert',
+  append = 'append',
 }


### PR DESCRIPTION
Fixes #16

Add support for Append Mode in GPT Response Rendering.

* Add a new output type `append` to the `PromptOutputType` enum in `src/prompts/type.ts`.
* Modify `src/main.tsx` to handle the new `append` output type.
* Append the response to the existing block content for the `append` output type in `src/main.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ahonn/logseq-plugin-ai-assistant/pull/19?shareId=72b0b962-672c-4fe0-81c4-62588117fc42).