### PR TITLE
feat: Remove thinking models <think> part

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import {
 import * as presetPrompts from './prompts';
 import { IPrompt, PromptOutputType } from './prompts/type';
 import settings, { ISettings } from './settings';
-import { getBlockContent } from './utils';
+import { escapeLLMOutput, getBlockContent } from './utils';
 
 function getPrompts() {
   const { customPrompts } = logseq.settings as unknown as ISettings;
@@ -74,7 +74,7 @@ function main() {
         const input = await template.formatMessages({ content });
         const message = await model.call(input);
         // only accept text response for now
-        const response = message.content.toString();
+        const response = escapeLLMOutput(message.content.toString());
 
         switch (output) {
           case PromptOutputType.property: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,3 +16,15 @@ export async function getBlockContent(block: BlockEntity, parentBlock = true, le
 
   return content;
 }
+
+
+export function escapeLLMOutput(text: string) {
+  function removeThinkingPart(text: string) {
+    // <think> ... </think>
+    const thinkingPattern = /<think>[\s\S]*?<\/think>/gi;
+    return text.replace(thinkingPattern, '');
+  }
+
+  let cleanedText = removeThinkingPart(text);
+  return cleanedText.trim();
+}


### PR DESCRIPTION
Thinking models like qwen3 adds a `<think>...</think>` part at the start of the output.
This commit removes that part from the output before writing to the Logseq block.

Before :
<img width="938" height="526" alt="image" src="https://github.com/user-attachments/assets/7cd46872-5188-479b-9608-085019ec2551" />

After :
<img width="938" height="155" alt="image" src="https://github.com/user-attachments/assets/007656ba-11d3-48df-a848-3875a34c0cb2" />

Tested with Logseq 0.10.14 in Ubuntu 24.04